### PR TITLE
Use `asgard-labs/hasktorch-nix` for cuda support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,7 +1,268 @@
 {
   "nodes": {
-    "hasktorch": {
+    "HTTP": {
       "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664759632,
+        "narHash": "sha256-SirBVxqVonZ0VhSJKqXdnoInhbpIOtN9gXESV6Mlt0k=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "a9acd50aefb3711dce5d1eb7f746b07562312b37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "nix-tools": "nix-tools",
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1664764787,
+        "narHash": "sha256-jscXUkqtN7Ivc/x6jT/d7vV435lgTK/4MdvRZVsKD9g=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
+        "type": "github"
+      }
+    },
+    "hasktorch": {
+      "inputs": {
+        "haskell-nix": "haskell-nix",
+        "iohkNix": "iohkNix",
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks",
+        "tokenizers": "tokenizers",
+        "utils": [
+          "hasktorch-nix",
+          "hasktorch",
+          "haskell-nix",
+          "flake-utils"
+        ]
+      },
       "locked": {
         "lastModified": 1685751068,
         "narHash": "sha256-hsl29VjfSOeRUFrnU9wDI6BYPoSbB/UzVDe0fJEEpPY=",
@@ -14,6 +275,70 @@
         "owner": "hasktorch",
         "repo": "hasktorch",
         "type": "github"
+      }
+    },
+    "hasktorch-nix": {
+      "inputs": {
+        "hasktorch": "hasktorch",
+        "inline-c": "inline-c",
+        "nixpkgs": "nixpkgs_4",
+        "tokenizers": "tokenizers_2",
+        "type-errors-pretty": "type-errors-pretty",
+        "typelevel-rewrite-rules": "typelevel-rewrite-rules"
+      },
+      "locked": {
+        "lastModified": 1688481902,
+        "narHash": "sha256-z6gwu6X31rm6rnWrw4C0hlAQ+AlkMYHxvdH85OVQO9Q=",
+        "owner": "asgard-labs",
+        "repo": "hasktorch-nix",
+        "rev": "52b05c7a4aced5f2180108bc71babb2ecd12f867",
+        "type": "github"
+      },
+      "original": {
+        "owner": "asgard-labs",
+        "repo": "hasktorch-nix",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
       }
     },
     "inline-c": {
@@ -33,7 +358,269 @@
         "type": "github"
       }
     },
+    "iohkNix": {
+      "inputs": {
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667394105,
+        "narHash": "sha256-YhS7zGd6jK/QM/+wWyj0zUBZmE3HOXAL/kpJptGYIWg=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "7fc7625a9ab2ba137bc70ddbc89a13d3fdb78c8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1629707199,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
+        "path": "./nix-tools",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-tools",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1663981975,
+        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1668984258,
+        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1663905476,
+        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1668994630,
+        "narHash": "sha256-1lqx6HLyw6fMNX/hXrrETG1vMvZRGm2XVC9O/Jt0T6c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af50806f7c6ab40df3e6b239099e8f8385f6c78b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1630084536,
+        "narHash": "sha256-ZFO/c1n5NNzHdY848Lfrbh8QN8MdP6oajbj4Z55rVXs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "40f337454d6c76bc12500564f4553d6853e83aeb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1687376262,
+        "narHash": "sha256-xtenf0Nc6So/5uaQqe8u3GVoAs/YdMUFsysPUuK8w1s=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7859e9c101fabbd62551b8f4260124a6e2f01a46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1688117947,
         "narHash": "sha256-eSVbMmqsGwPlJy8jqzxwZ+cJzu8TpI2KSSKm8xVw+XQ=",
@@ -49,17 +636,98 @@
         "type": "github"
       }
     },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1669829516,
+        "narHash": "sha256-laWMD/TZzyrulu8xLNoSPertXOxjRD7BrcAVwKl+NyQ=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "471c7f1ecace25e39099206431300322632d25c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "hasktorch": "hasktorch",
-        "inline-c": "inline-c",
-        "nixpkgs": "nixpkgs",
-        "tokenizers": "tokenizers",
-        "type-errors-pretty": "type-errors-pretty",
-        "typelevel-rewrite-rules": "typelevel-rewrite-rules"
+        "hasktorch-nix": "hasktorch-nix",
+        "nixpkgs": "nixpkgs_5"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664586901,
+        "narHash": "sha256-ROUeTRTJ0Yktjqg+vXOYCXKWjIqutJl4rw5KsFZ0kCo=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "f1abb218b94cc1e94bc52185dab499f6705b6edd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
       }
     },
     "tokenizers": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": [
+          "hasktorch-nix",
+          "hasktorch",
+          "nixpkgs"
+        ],
+        "utils": [
+          "hasktorch-nix",
+          "hasktorch",
+          "haskell-nix",
+          "flake-utils"
+        ]
+      },
+      "locked": {
+        "lastModified": 1630175276,
+        "narHash": "sha256-cTZd9yHt9BdVHaobdkzSACbLyBfXvhqGQpqa+qwLlJ8=",
+        "owner": "hasktorch",
+        "repo": "tokenizers",
+        "rev": "ea1de2ec7230d6d315fb1028e8d58b09a7a7c2ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hasktorch",
+        "ref": "flakes",
+        "repo": "tokenizers",
+        "type": "github"
+      }
+    },
+    "tokenizers_2": {
       "flake": false,
       "locked": {
         "lastModified": 1621450526,

--- a/flake.nix
+++ b/flake.nix
@@ -3,59 +3,37 @@
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
 
-  inputs.hasktorch.url = github:hasktorch/hasktorch;
-  inputs.hasktorch.flake = false;
-
-  inputs.tokenizers.url = github:hasktorch/tokenizers/9d25f0ba303193e97f8b22b9c93cbc84725886c3;
-  inputs.tokenizers.flake = false;
-
-  inputs.typelevel-rewrite-rules.url = github:hasktorch/typelevel-rewrite-rules/4176e10d4de2d1310506c0fcf6a74956d81d59b6;
-  inputs.typelevel-rewrite-rules.flake = false;
-
-  inputs.type-errors-pretty.url = github:hasktorch/type-errors-pretty/32d7abec6a21c42a5f960d7f4133d604e8be79ec;
-  inputs.type-errors-pretty.flake = false;
-
-  inputs.inline-c.url = github:fpco/inline-c/2d0fe9b2f0aa0e1aefc7bfed95a501e59486afb0;
-  inputs.inline-c.flake = false;
+  inputs.hasktorch-nix.url = "github:asgard-labs/hasktorch-nix";
 
   outputs = inputs:
 
     let
+
+      inherit (inputs.nixpkgs) lib;
+
       system = "x86_64-linux";
 
-      overlay = self: super: {
-        libtorch = self.callPackage "${inputs.hasktorch}/nix/libtorch.nix" {
-          cudaSupport = false;
-          device = "cpu";
-        };
-        haskell = let
-            packageOverrides = hself: hsuper: {
-              tokenizers = hself.callCabal2nix "tokenizers" "${inputs.tokenizers}/bindings/haskell/tokenizers-haskell" {};
-              typelevel-rewrite-rules = hself.callCabal2nix "typelevel-rewrite-rules" inputs.typelevel-rewrite-rules {};
-              type-errors-pretty = hself.callCabal2nix "type-errors-pretty" inputs.type-errors-pretty {};
-              inline-c = hself.callCabal2nix "inline-c" "${inputs.inline-c}/inline-c" {};
-              inline-c-cpp = hself.callCabal2nix "inline-c-cpp" "${inputs.inline-c}/inline-c-cpp" {};
+      ghc-name = "ghc924";
 
-              codegen = hself.callCabal2nix "codegen" "${inputs.hasktorch}/codegen" {};
-              libtorch-ffi = self.haskell.lib.compose.appendConfigureFlag "--extra-include-dirs=${self.libtorch.dev}/include/torch/csrc/api/include"
-                (hself.callCabal2nix "libtorch-ffi" "${inputs.hasktorch}/libtorch-ffi" {
-                  torch = self.libtorch;
-                  c10 = self.libtorch;
-                  torch_cpu = self.libtorch;
-                });
-              libtorch-ffi-helper = hself.callCabal2nix "libtorch-ffi-helper" "${inputs.hasktorch}/libtorch-ffi-helper" {};
-              hasktorch = hself.callCabal2nix "hasktorch" "${inputs.hasktorch}/hasktorch" {};
-              examples = hself.callCabal2nix "examples" "${inputs.hasktorch}/examples" {};
-              experimental = hself.callCabal2nix "experimental" "${inputs.hasktorch}/experimental" {};
+      hasktorch-device = "cuda-11"; # There are three variants "cpu" "cuda-10" "cuda-11"
 
-              hasktorch-skeleton = hself.callCabal2nix "hastorch-skeleton" ./hasktorch-skeleton {};
-            };
-          in super.haskell // { inherit packageOverrides; };
-        haskellPackages = pkgs.haskell.packages.ghc924;
-      };
+      overlay = lib.composeManyExtensions [
+        inputs.hasktorch-nix.overlay
+        (self: super: { haskellPackages = self.haskell.packages.${ghc-name}; })
+        (self: super: {
+          haskell = super.haskell // {
+            packageOverrides =
+              lib.composeExtensions
+                super.haskell.packageOverrides
+                (self.haskell.lib.packageSourceOverrides {
+                  hasktorch-skeleton = ./hasktorch-skeleton; });};})
+      ];
 
       pkgs = import inputs.nixpkgs { inherit system; overlays = [ overlay ]; };
 
+      hlib = pkgs.haskell.lib;
+
+      haskPkgs = __mapAttrs (_: ps: ps.haskellPackages) pkgs.hasktorchPkgs;
 
     in
 
@@ -63,26 +41,34 @@
 
         inherit pkgs overlay;
 
-        packages.${system} = with pkgs; {
-          default = haskellPackages.hasktorch-skeleton;
-          hasktorch = haskellPackages.hasktorch;
-          hasktorch-skeleton = haskellPackages.hasktorch-skeleton;
+        packages.${system} = {
+          default = haskPkgs.${hasktorch-device}.hasktorch-skeleton;
+          hasktorch = haskPkgs.${hasktorch-device}.hasktorch;
+          hasktorch-skeleton = __mapAttrs (_: hpkgs: hpkgs.hasktorch-skeleton) haskPkgs;
         };
 
-        devShell.${system} = with pkgs; haskellPackages.shellFor {
-          packages = p: with p; [
-            hasktorch-skeleton
-          ];
-          buildInputs =
-            (with haskellPackages;
-            [ haskell-language-server
-              threadscope
-            ]) ++
-            [
-              ghcid.bin
-              cabal-install
-            ];
-        };
+        devShell.${system} =
+          let
+            hpkgs = haskPkgs.${hasktorch-device};
+          in
+            hpkgs.shellFor {
+
+              packages = p: with p; [
+                hasktorch-skeleton
+              ];
+
+              buildInputs =
+                (with hpkgs;
+                  [ haskell-language-server
+                    threadscope
+                  ]) ++
+                (with pkgs;
+                  [
+                    ghcid.bin
+                    cabal-install
+                  ]);
+            };
+
       };
 
 }


### PR DESCRIPTION
With the `inputs.hasktorch-nix.overlay` applied, there are three variants of of `pkgs` in `pkgs.hasktorchPkgs` with hasktorch backend chosen among `cpu`, `cuda-10`, and `cuda-11`. In this PR, the default build is set for `cuda-11`.

It's time to experiment with the real GPU machine.